### PR TITLE
feat(iam): add EC2 role/profile for SSM access

### DIFF
--- a/01-runner-ec2-terraform/main.tf
+++ b/01-runner-ec2-terraform/main.tf
@@ -18,3 +18,26 @@ locals {
     Project = local.name_prefix
   }
 }
+
+# --- EC2に付けるIAMロール（SSM接続のため） ---
+data "aws_iam_policy_document" "assume_ec2" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals { type = "Service", identifiers = ["ec2.amazonaws.com"] }
+  }
+}
+
+resource "aws_iam_role" "runner_role" {
+  name               = "${local.name_prefix}-runner-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_ec2.json
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.runner_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "runner_profile" {
+  name = "${local.name_prefix}-runner-profile"
+  role = aws_iam_role.runner_role.name
+}


### PR DESCRIPTION
- Create IAM role for EC2 runner
- Attach AmazonSSMManagedInstanceCore
- Add instance profile